### PR TITLE
Add option to make sorting optional

### DIFF
--- a/src/pdfcat/pdfcat.py
+++ b/src/pdfcat/pdfcat.py
@@ -61,8 +61,15 @@ def parse_args():
         description="A simple tool to merge multiple PDFs at the command line."
     )
     parser.add_argument("output_file", help="name of final merged PDF file")
-    parser.add_argument("input_files", help="list of PDF files to merge", nargs='+')
-    parser.add_argument("-V", "--version", action="version", version=f"{prog} {version(prog)}")
+    parser.add_argument("input_files", 
+                        help="list of PDF files to merge", nargs='+')
+    parser.add_argument("-V", "--version", 
+                        action="version", 
+                        version=f"{prog} {version(prog)}")
+    parser.add_argument("-s", "--sorted", 
+                        action="store_true", 
+                        help="merge the PDFs in an order sorted by name")
+
     args = parser.parse_args()
 
     input_files = [file for arg in args.input_files for file in glob.glob(arg)]

--- a/src/pdfcat/pdfcat.py
+++ b/src/pdfcat/pdfcat.py
@@ -73,7 +73,9 @@ def parse_args():
     args = parser.parse_args()
 
     input_files = [file for arg in args.input_files for file in glob.glob(arg)]
-    input_files = natsorted(input_files)
+    
+    if args.sorted:
+        input_files = natsorted(input_files)
 
     validate_args(args.output_file, input_files)
     


### PR DESCRIPTION
Make to tool always sort in the order specified by the user. That is, don't sort the input file names unless explicitly specified by the user.

This PR adds an option to sort the input files by name only if the user specified to do so.